### PR TITLE
feat: added a valid type for suggestions list

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -59,7 +59,7 @@ module.exports = {
           replacementPrefix: prefix,
           rightLabel: rightLabel,
           text: text,
-          type: 'tailwind'
+          type: 'property'
         };
 
         if (rightLabel.indexOf('color') >= 0) {


### PR DESCRIPTION
Hi! Thank you for this nice package, automatic completion seems to work well (for now I have only tested projects in `react`) and all classes in suggestions seem to be updated! Top! :)

One thing that I can't find so pretty is to leave the cell of the type of empty suggestion classes....

<img width="446" alt="tailwind" src="https://user-images.githubusercontent.com/15775323/112052156-183b0680-8b53-11eb-8055-1f81aebbbcbc.png">

I have updated the self-compliance with a valid type, in this case `property` here is the result...

<img width="440" alt="property" src="https://user-images.githubusercontent.com/15775323/112052191-21c46e80-8b53-11eb-8930-6ac6c0150c56.png">

it seems more complete now...what do you say?